### PR TITLE
fix: prevent error popup on windows

### DIFF
--- a/status/libstatus/core.nim
+++ b/status/libstatus/core.nim
@@ -21,7 +21,6 @@ proc callPrivateRPC*(methodName: string, payload = %* []): string =
     let response = status_go.callPrivateRPC($inputJSON)
     result = $response
     if parseJSON(result).hasKey("error"):
-      writeStackTrace()
       error "rpc response error", result, payload, methodName
   except Exception as e:
     error "error doing rpc request", methodName = methodName, exception=e.msg


### PR DESCRIPTION
fixes #3384

While this procedure is helpful for debugging it shows
a popup on windows build.

I couldn't reproduce the error but it can simply be network error
or timeout or url not available

Original PR: https://github.com/status-im/status-desktop/pull/3417