### PR TITLE
fix: networks serialisation

### DIFF
--- a/status/wallet2/network.nim
+++ b/status/wallet2/network.nim
@@ -1,18 +1,18 @@
 from json import JsonNode, `%*`
 from strformat import fmt
-from json_serialization import serializedFieldName
+import json_serialization
 
 type Network* = ref object
-  chainID* {.serializedFieldName("chain_id").}: int
-  nativeCurrencyDecimals* {.serializedFieldName("native_currency_decimals").}: int
+  chainID* {.serializedFieldName("chainId").}: int
+  nativeCurrencyDecimals* {.serializedFieldName("nativeCurrencyDecimals").}: int
   layer* {.serializedFieldName("layer").}: int
-  chainName* {.serializedFieldName("chain_name").}: string
-  rpcURL* {.serializedFieldName("rpc_url").}: string
-  blockExplorerURL* {.serializedFieldName("block_explorer_url").}: string
-  iconURL* {.serializedFieldName("icon_url").}: string
-  nativeCurrencyName* {.serializedFieldName("native_currency_name").}: string
-  nativeCurrencySymbol* {.serializedFieldName("native_currency_symbol").}: string
-  isTest* {.serializedFieldName("is_test").}: bool
+  chainName* {.serializedFieldName("chainName").}: string
+  rpcURL* {.serializedFieldName("rpcUrl").}: string
+  blockExplorerURL* {.serializedFieldName("blockExplorerUrl").}: string
+  iconURL* {.serializedFieldName("iconUrl").}: string
+  nativeCurrencyName* {.serializedFieldName("nativeCurrencyName").}: string
+  nativeCurrencySymbol* {.serializedFieldName("nativeCurrencySymbol").}: string
+  isTest* {.serializedFieldName("isTest").}: bool
   enabled* {.serializedFieldName("enabled").}: bool
 
 proc `$`*(self: Network): string =


### PR DESCRIPTION
Deserialization was attempting to deserialize via snake case, however the `json` definitions in status-go are using camel case.

The odd thing here is that when *serializing*, status-go expects the fields to be snake cased. Ideally, these should be consistent so that we can use both `Json.encode` and `Json.decode`.