### PR TITLE
Refactor/libstatus stickers

### DIFF
--- a/status/eth/transactions.nim
+++ b/status/eth/transactions.nim
@@ -1,8 +1,5 @@
 import
-  json
-
-import
-  json_serialization, chronicles, web3/ethtypes
+  json, json_serialization, chronicles, web3/ethtypes
 
 import
   ../libstatus/core, ../types/[rpc_response, transaction], ../libstatus/conversions
@@ -25,6 +22,12 @@ proc sendTransaction*(tx: TransactionData, password: string): RpcResponse =
 
 proc call*(tx: TransactionData): RpcResponse =
   let responseStr = core.callPrivateRPC("eth_call", %*[%tx, "latest"])
+  result = Json.decode(responseStr, RpcResponse)
+  if not result.error.isNil:
+    raise newException(RpcException, "Error calling method: " & result.error.message)
+
+proc eth_call*(payload = %* []): RpcResponse =
+  let responseStr = core.callPrivateRPC("eth_call", payload)
   result = Json.decode(responseStr, RpcResponse)
   if not result.error.isNil:
     raise newException(RpcException, "Error calling method: " & result.error.message)

--- a/status/libstatus/stickers.nim
+++ b/status/libstatus/stickers.nim
@@ -9,56 +9,7 @@ from nimcrypto import fromHex
 
 import # status-desktop libs
   ./core as status, ../types/[sticker, setting, rpc_response], 
-  ../eth/contracts, ./settings, ./edn_helpers
-
-proc decodeContentHash*(value: string): string =
-  if value == "":
-    return ""
-
-  # eg encoded sticker multihash cid:
-  #  e30101701220eab9a8ef4eac6c3e5836a3768d8e04935c10c67d9a700436a0e53199e9b64d29
-  #  e3017012205c531b83da9dd91529a4cf8ecd01cb62c399139e6f767e397d2f038b820c139f (testnet)
-  #  e3011220c04c617170b1f5725070428c01280b4c19ae9083b7e6d71b7a0d2a1b5ae3ce30 (testnet)
-  #
-  # The first 4 bytes (in hex) represent:
-  # e3 = codec identifier "ipfs-ns" for content-hash
-  # 01 = unused - sometimes this is NOT included (ie ropsten)
-  # 01 = CID version (effectively unused, as we will decode with CIDv0 regardless)
-  # 70 = codec identifier "dag-pb"
-
-  # ipfs-ns
-  if value[0..1] != "e3":
-    warn "Could not decode sticker. It may still be valid, but requires a different codec to be used", hash=value
-    return ""
-
-  try:
-    # dag-pb
-    let defaultCodec = parseHexInt("70") #dag-pb
-    var codec = defaultCodec # no codec specified
-    var codecStartIdx = 2 # idx of where codec would start if it was specified
-    # handle the case when starts with 0xe30170 instead of 0xe3010170
-    if value[2..5] == "0101":
-      codecStartIdx = 6
-      codec = parseHexInt(value[6..7])
-    elif value[2..3] == "01" and value[4..5] != "12":
-      codecStartIdx = 4
-      codec = parseHexInt(value[4..5])
-
-    # strip the info we no longer need
-    var multiHashStr = value[codecStartIdx + 2..<value.len]
-
-    # The rest of the hash identifies the multihash algo, length, and digest
-    # More info: https://multiformats.io/multihash/
-    # 12 = identifies sha2-256 hash
-    # 20 = multihash length = 32
-    # ...rest = multihash digest
-    let multiHash = MultiHash.init(nimcrypto.fromHex(multiHashStr)).get()
-    let resultTyped = Cid.init(CIDv0, MultiCodec.codec(codec), multiHash).get()
-    result = $resultTyped
-    trace "Decoded sticker hash", cid=result
-  except Exception as e:
-    error "Error decoding sticker", hash=value, exception=e.msg
-    raise
+  ../eth/contracts, ./settings, ./edn_helpers, ../utils
 
 # Retrieves number of sticker packs owned by user
 # See https://notes.status.im/Q-sQmQbpTOOWCQcYiXtf5g#Read-Sticker-Packs-owned-by-a-user

--- a/status/stickers.nim
+++ b/status/stickers.nim
@@ -7,11 +7,10 @@ import # project deps
 import # local deps
   utils as status_utils,
   eth/contracts as status_contracts,
-  libstatus/stickers as status_stickers, transactions,
+  stickers_backend as status_stickers, transactions,
   libstatus/wallet, ../eventemitter
 import ./types/[sticker, transaction, rpc_response]
 from utils as libstatus_utils import eth2Wei, gwei2Wei, toUInt64, parseAddress
-
 
 logScope:
   topics = "stickers-model"

--- a/status/stickers.nim
+++ b/status/stickers.nim
@@ -5,6 +5,7 @@ import # project deps
   chronicles, web3/[ethtypes, conversions], stint
 
 import # local deps
+  utils as status_utils,
   eth/contracts as status_contracts,
   libstatus/stickers as status_stickers, transactions,
   libstatus/wallet, ../eventemitter
@@ -143,7 +144,7 @@ proc addStickerToRecent*(self: StickersModel, sticker: Sticker, save: bool = fal
     status_stickers.saveRecentStickers(self.recentStickers)
 
 proc decodeContentHash*(value: string): string =
-  result = status_stickers.decodeContentHash(value)
+  result = status_utils.decodeContentHash(value)
 
 proc getPackIdFromTokenId*(tokenId: Stuint[256]): int =
   result = status_stickers.getPackIdFromTokenId(tokenId)

--- a/status/utils.nim
+++ b/status/utils.nim
@@ -1,10 +1,63 @@
+import 
+  atomics, json, tables, sequtils, httpclient, net
 import json, random, strutils, strformat, tables, chronicles, unicode, times
+import 
+  json_serialization, chronicles, libp2p/[multihash, multicodec, cid], stint, nimcrypto
 from sugar import `=>`, `->`
 import stint
 from times import getTime, toUnix, nanosecond
 import signing_phrases
 from web3 import Address, fromHex
 import web3/ethhexstrings
+
+proc decodeContentHash*(value: string): string =
+  if value == "":
+    return ""
+
+  # eg encoded sticker multihash cid:
+  #  e30101701220eab9a8ef4eac6c3e5836a3768d8e04935c10c67d9a700436a0e53199e9b64d29
+  #  e3017012205c531b83da9dd91529a4cf8ecd01cb62c399139e6f767e397d2f038b820c139f (testnet)
+  #  e3011220c04c617170b1f5725070428c01280b4c19ae9083b7e6d71b7a0d2a1b5ae3ce30 (testnet)
+  #
+  # The first 4 bytes (in hex) represent:
+  # e3 = codec identifier "ipfs-ns" for content-hash
+  # 01 = unused - sometimes this is NOT included (ie ropsten)
+  # 01 = CID version (effectively unused, as we will decode with CIDv0 regardless)
+  # 70 = codec identifier "dag-pb"
+
+  # ipfs-ns
+  if value[0..1] != "e3":
+    warn "Could not decode sticker. It may still be valid, but requires a different codec to be used", hash=value
+    return ""
+
+  try:
+    # dag-pb
+    let defaultCodec = parseHexInt("70") #dag-pb
+    var codec = defaultCodec # no codec specified
+    var codecStartIdx = 2 # idx of where codec would start if it was specified
+    # handle the case when starts with 0xe30170 instead of 0xe3010170
+    if value[2..5] == "0101":
+      codecStartIdx = 6
+      codec = parseHexInt(value[6..7])
+    elif value[2..3] == "01" and value[4..5] != "12":
+      codecStartIdx = 4
+      codec = parseHexInt(value[4..5])
+
+    # strip the info we no longer need
+    var multiHashStr = value[codecStartIdx + 2..<value.len]
+
+    # The rest of the hash identifies the multihash algo, length, and digest
+    # More info: https://multiformats.io/multihash/
+    # 12 = identifies sha2-256 hash
+    # 20 = multihash length = 32
+    # ...rest = multihash digest
+    let multiHash = MultiHash.init(nimcrypto.fromHex(multiHashStr)).get()
+    let resultTyped = Cid.init(CIDv0, MultiCodec.codec(codec), multiHash).get()
+    result = $resultTyped
+    trace "Decoded sticker hash", cid=result
+  except Exception as e:
+    error "Error decoding sticker", hash=value, exception=e.msg
+    raise
 
 proc getTimelineChatId*(pubKey: string = ""): string =
   if pubKey == "":

--- a/status/wallet/collectibles.nim
+++ b/status/wallet/collectibles.nim
@@ -8,6 +8,7 @@ import # vendor libs
 import # status-desktop libs
   ../libstatus/core as status, ../eth/contracts as contracts,
   ../stickers as status_stickers,
+  ../utils as status_utils,
   web3/[conversions, ethtypes], ../utils, account
 
 const CRYPTOKITTY* = "cryptokitty"
@@ -242,7 +243,7 @@ proc getStickers*(address: Address, running: var Atomic[bool]): string =
       let sticker = availableStickerPacks[stickerId]
       stickers.add(Collectible(id: $tokensIds[index],
         name: sticker.name,
-        image: fmt"https://ipfs.infura.io/ipfs/{status_stickers.decodeContentHash(sticker.preview)}",
+        image: fmt"https://ipfs.infura.io/ipfs/{status_utils.decodeContentHash(sticker.preview)}",
         collectibleType: STICKER,
         description: sticker.author,
         externalUrl: "")

--- a/status/wallet2/collectibles.nim
+++ b/status/wallet2/collectibles.nim
@@ -8,6 +8,7 @@ import # vendor libs
 import # status-desktop libs
   ../libstatus/core as status, ../eth/contracts as contracts,
   ../stickers as status_stickers,
+  ../utils as status_utils,
   web3/[conversions, ethtypes], ../utils, account
 
 const CRYPTOKITTY* = "cryptokitty"
@@ -242,7 +243,7 @@ proc getStickers*(address: Address, running: var Atomic[bool]): string =
       let sticker = availableStickerPacks[stickerId]
       stickers.add(Collectible(id: $tokensIds[index],
         name: sticker.name,
-        image: fmt"https://ipfs.infura.io/ipfs/{status_stickers.decodeContentHash(sticker.preview)}",
+        image: fmt"https://ipfs.infura.io/ipfs/{status_utils.decodeContentHash(sticker.preview)}",
         collectibleType: STICKER,
         description: sticker.author,
         externalUrl: "")


### PR DESCRIPTION
first pass at it, removes sticker logic completely from libstatus (didn't belong there), on a second pass the new stickers_backend.nim file needs to be merged with stickers.nim and then further refactored and simplified.