### PR TITLE
chore(@desktop/chat): replies are not working in communities

### DIFF
--- a/status/chat.nim
+++ b/status/chat.nim
@@ -335,8 +335,15 @@ proc processMessageUpdateAfterSend(self: ChatModel, response: string): (seq[Chat
   if chats.len == 0 and messages.len == 0:
     self.events.emit("messageSendingFailed", Args())
     return
+
+  # This fixes issue#3490
+  var msg = messages[0]
+  for m in messages:
+    if(m.responseTo.len > 0):
+      msg = m
+      break
   
-  self.events.emit("messageSendingSuccess", MessageSendingSuccess(message: messages[0], chat: chats[0]))
+  self.events.emit("messageSendingSuccess", MessageSendingSuccess(message: msg, chat: chats[0]))
 
 proc sendMessage*(self: ChatModel, chatId: string, msg: string, replyTo: string = "", contentType: int = ContentType.Message.int, communityId: string = "") =
   var response = status_chat.sendChatMessage(chatId, msg, replyTo, contentType, communityId)


### PR DESCRIPTION
This check is here, because of issue#3490, that was happening due to different
messages' order (received from status go). We were emitting always a message on
index 0, what in some cases was not the reply message (doesn't contain "responseTo"
value). This should be handled in status-go but since that part is used by mobile
also and it is working for them, change is applied here.

Fixes: #3490