### PR TITLE
fix: Keep only one place to store contacts and index

### DIFF
--- a/status/types/profile.nim
+++ b/status/types/profile.nim
@@ -16,7 +16,7 @@ type Profile* = ref object
   systemTags*: seq[string]
 
 proc `$`*(self: Profile): string =
-  return fmt"Profile(id:{self.id}, username:{self.username})"
+  return fmt"Profile(id:{self.id}, username:{self.username}, systemTags: {self.systemTags}, ensName: {self.ensName})"
 
 proc toProfileModel*(profile: JsonNode): Profile =
   var systemTags: seq[string] = @[]


### PR DESCRIPTION
* Keep only one store for contacts rather than one in chat and one in contacts.
=> That was causing issues with sync
* sendContactUpdate (renamed from requestContactUpdate) is now sending 2 new parameters: the ens name as well as the picture to avoid them to be replace with empty