### PR TITLE
feat(chat): support hiding of messages for blocked contacts

### DIFF
--- a/status/contacts.nim
+++ b/status/contacts.nim
@@ -15,6 +15,9 @@ type
   ContactUpdateArgs* = ref object of Args
     contacts*: seq[Profile]
 
+  ContactIdArgs* = ref object of Args
+    id*: string
+
 proc newContactModel*(events: EventEmitter): ContactModel =
     result = ContactModel()
     result.events = events
@@ -39,13 +42,13 @@ proc blockContact*(self: ContactModel, id: string): string =
   var contact = self.getContactByID(id)
   contact.systemTags.add(contactBlocked)
   discard self.saveContact(contact)
-  self.events.emit("contactBlocked", Args())
+  self.events.emit("contactBlocked", ContactIdArgs(id: id))
 
 proc unblockContact*(self: ContactModel, id: string): string =
   var contact = self.getContactByID(id)
   contact.systemTags.delete(contact.systemTags.find(contactBlocked))
   discard self.saveContact(contact)
-  self.events.emit("contactUnblocked", Args())
+  self.events.emit("contactUnblocked", ContactIdArgs(id: id))
 
 proc getContacts*(self: ContactModel, useCache: bool = true): seq[Profile] =
   let (contacts, usedCache) = status_contacts.getContacts(useCache)

--- a/status/types/message.nim
+++ b/status/types/message.nim
@@ -74,6 +74,7 @@ type Message* = object
   isPinned*: bool
   pinnedBy*: string
   deleted*: bool
+  hide*: bool
 
 proc `$`*(self: Message): string =
   result = fmt"Message(id:{self.id}, chatId:{self.chatId}, clock:{self.clock}, from:{self.fromAuthor}, contentType:{self.contentType})"
@@ -132,7 +133,8 @@ proc toMessage*(jsonMsg: JsonNode): Message =
       communityId: $jsonMsg{"communityId"}.getStr,
       audioDurationMs: jsonMsg{"audioDurationMs"}.getInt,
       deleted: jsonMsg{"deleted"}.getBool,
-      hasMention: false
+      hasMention: false,
+      hide: false
     )
 
   if contentType == ContentType.Gap:


### PR DESCRIPTION
Adds a `hide` field to the `Message` object to support hiding of messages for blocked contacts.