### PR TITLE
chore(@desktop/chat): Chat type's `toJsonNode` proc extended

### DIFF
--- a/status/types/chat.nim
+++ b/status/types/chat.nim
@@ -56,6 +56,7 @@ proc toJsonNode*(self: Chat): JsonNode =
     "color": self.color,
     "deletedAtClockValue": self.deletedAtClockValue,
     "id": self.id,
+    "communityId": self.communityId,
     "lastClockValue": self.lastClockValue,
     "lastMessage": nil,
     "members": self.members.toJsonNode,


### PR DESCRIPTION
`communityId` field added to the Chat `toJsonNode` procedure