### PR TITLE
fix: delete message

### DIFF
--- a/status/chat.nim
+++ b/status/chat.nim
@@ -359,8 +359,7 @@ proc sendImages*(self: ChatModel, chatId: string, images: var seq[string]) =
   discard self.processMessageUpdateAfterSend(response)
 
 proc deleteMessageAndSend*(self: ChatModel, messageId: string) =
-  var response = status_chat.deleteMessageAndSend(messageId)    
-  discard self.processMessageUpdateAfterSend(response)
+  discard status_chat.deleteMessageAndSend(messageId)
 
 proc sendSticker*(self: ChatModel, chatId: string, replyTo: string, sticker: Sticker) =
   var response = status_chat.sendStickerMessage(chatId, replyTo, sticker)


### PR DESCRIPTION
https://github.com/status-im/status-desktop/issues/3632

Tested in Group/Communities/1-1/Public chats

processMessageUpdateAfterSend handle the case when there is a message in the reply, in this case there is not, the message is deleted from status-go and the message is deleted from the view inside status-desktop