### PR TITLE
fix(status/chat): extend editCommunityChannel API to accept `position…

### DIFF
--- a/status/chat.nim
+++ b/status/chat.nim
@@ -495,8 +495,8 @@ proc editCommunity*(self: ChatModel, id: string, name: string, description: stri
 proc createCommunityChannel*(self: ChatModel, communityId: string, name: string, description: string): Chat =
   result = status_chat.createCommunityChannel(communityId, name, description)
 
-proc editCommunityChannel*(self: ChatModel, communityId: string, channelId: string, name: string, description: string, categoryId: string): Chat =
-  result = status_chat.editCommunityChannel(communityId, channelId, name, description, categoryId)
+proc editCommunityChannel*(self: ChatModel, communityId: string, channelId: string, name: string, description: string, categoryId: string, position: int): Chat =
+  result = status_chat.editCommunityChannel(communityId, channelId, name, description, categoryId, position)
 
 proc deleteCommunityChat*(self: ChatModel, communityId: string, channelId: string) =
   status_chat.deleteCommunityChat(communityId, channelId)

--- a/status/statusgo_backend/chat.nim
+++ b/status/statusgo_backend/chat.nim
@@ -324,7 +324,7 @@ proc createCommunityChannel*(communityId: string, name: string, description: str
   if rpcResult{"result"} != nil and rpcResult{"result"}.kind != JNull:
     result = rpcResult["result"]["chats"][0].toChat()
 
-proc editCommunityChannel*(communityId: string, channelId: string, name: string, description: string, categoryId: string): Chat =
+proc editCommunityChannel*(communityId: string, channelId: string, name: string, description: string, categoryId: string, position: int): Chat =
   let rpcResult = callPrivateRPC("editCommunityChat".prefix, %*[
     communityId,
     channelId.replace(communityId, ""),
@@ -345,7 +345,8 @@ proc editCommunityChannel*(communityId: string, channelId: string, name: string,
         #   }
         # ]
       },
-      "category_id": categoryId
+      "category_id": categoryId,
+      "position": position
     }]).parseJSON()
 
   if rpcResult{"error"} != nil:


### PR DESCRIPTION
…` property

This was missing and causes chat item positions in communities to be reset
to 0.