### PR TITLE
feat(chat): add bindings to `markActivityCenterNotificationsUnread` API

### DIFF
--- a/status/chat.nim
+++ b/status/chat.nim
@@ -74,6 +74,11 @@ type
     channelId*: string
     notificationTypes*: seq[ActivityCenterNotificationType]
 
+  MarkAsUnreadNotificationProperties* = ref object of Args
+    communityId*: string
+    channelId*: string
+    notificationTypes*: seq[ActivityCenterNotificationType]
+
 type ChatModel* = ref object
   publicKey*: string
   events*: EventEmitter
@@ -614,6 +619,16 @@ markAsReadProps: MarkAsReadNotificationProperties): string =
     result = e.msg
   
   self.events.emit("markNotificationsAsRead", markAsReadProps)
+
+proc markActivityCenterNotificationUnread*(self: ChatModel, notificationId: string,
+markAsUnreadProps: MarkAsUnreadNotificationProperties): string =
+  try:
+    status_chat.markActivityCenterNotificationsUnread(@[notificationId])
+  except Exception as e:
+    error "Error marking as unread", msg = e.msg
+    result = e.msg
+  
+  self.events.emit("markNotificationsAsUnread", markAsUnreadProps)
 
 proc acceptActivityCenterNotifications*(self: ChatModel, ids: seq[string]): string =
   try:

--- a/status/statusgo_backend/chat.nim
+++ b/status/statusgo_backend/chat.nim
@@ -558,6 +558,9 @@ proc markAllActivityCenterNotificationsRead*() =
 proc markActivityCenterNotificationsRead*(ids: seq[string]) =
   discard callPrivateRPC("markActivityCenterNotificationsRead".prefix, %*[ids])
 
+proc markActivityCenterNotificationsUnread*(ids: seq[string]) =
+  discard callPrivateRPC("markActivityCenterNotificationsUnread".prefix, %*[ids])
+
 proc acceptActivityCenterNotifications*(ids: seq[string]): string =
   result =  callPrivateRPC("acceptActivityCenterNotifications".prefix, %*[ids])
 


### PR DESCRIPTION
This is needed so clients can implement the functionality of marking notifications
as unread.