### PR TITLE
feat: wakuv2 rendezvous

### DIFF
--- a/status/statusgo_backend/accounts.nim
+++ b/status/statusgo_backend/accounts.nim
@@ -30,12 +30,11 @@ proc getDefaultNodeConfig*(fleetConfig: FleetConfig, installationId: string): Js
   result["UpstreamConfig"]["URL"] = upstreamUrl
   result["ShhextConfig"]["InstallationID"] = newJString(installationId)
 
-  # TODO: fleet.status.im should have different sections depending on the node type
-  #       or maybe it's not necessary because a node has the identify protocol
   result["ClusterConfig"]["RelayNodes"] =  %* fleetConfig.getNodes(fleet, FleetNodes.Waku)
   result["ClusterConfig"]["StoreNodes"] =  %* fleetConfig.getNodes(fleet, FleetNodes.Waku)
   result["ClusterConfig"]["FilterNodes"] =  %* fleetConfig.getNodes(fleet, FleetNodes.Waku)
   result["ClusterConfig"]["LightpushNodes"] =  %* fleetConfig.getNodes(fleet, FleetNodes.Waku)
+  result["ClusterConfig"]["WakuRendezvousNodes"] =  %* @[]
 
   # TODO: commented since it's not necessary (we do the connections thru C bindings). Enable it thru an option once status-nodes are able to be configured in desktop
   # result["ListenAddr"] = if existsEnv("STATUS_PORT"): newJString("0.0.0.0:" & $getEnv("STATUS_PORT")) else: newJString("0.0.0.0:30305")

--- a/status/statusgo_backend/accounts/constants.nim
+++ b/status/statusgo_backend/accounts/constants.nim
@@ -168,7 +168,8 @@ var NODE_CONFIG* = %* {
     "Enabled": false,
     "Host": "0.0.0.0",
     "Port": 0,
-    "LightClient": false
+    "LightClient": false,
+    "DiscoveryLimit": 20
   },
   "WalletConfig": {
     "Enabled": true

--- a/status/statusgo_backend/settings.nim
+++ b/status/statusgo_backend/settings.nim
@@ -159,8 +159,10 @@ proc setWakuVersion*(newVersion: int) =
   else:
     nodeConfig["WakuConfig"]["Enabled"] = newJBool(false)
     nodeConfig["WakuV2Config"]["Enabled"] = newJBool(true)
+    nodeConfig["WakuV2Config"]["DiscoveryLimit"] = newJInt(20)
     nodeConfig["NoDiscovery"] = newJBool(true)
     nodeConfig["Rendezvous"] = newJBool(false)
+    nodeConfig["WakuV2Config"]["Rendezvous"] = newJBool(true)
   discard saveSetting(Setting.NodeConfig, nodeConfig)
 
 proc setNetwork*(network: string): StatusGoError =
@@ -205,7 +207,6 @@ proc setFleet*(fleetConfig: FleetConfig, fleet: Fleet): StatusGoError =
   let statusGoResult = saveSetting(Setting.Fleet, $fleet)
   if statusGoResult.error != "":
     return statusGoResult
-
   var nodeConfig = getNodeConfig()
   nodeConfig["ClusterConfig"]["Fleet"] = newJString($fleet)
   nodeConfig["ClusterConfig"]["BootNodes"] = %* fleetConfig.getNodes(fleet, FleetNodes.Bootnodes)
@@ -216,6 +217,11 @@ proc setFleet*(fleetConfig: FleetConfig, fleet: Fleet): StatusGoError =
   nodeConfig["ClusterConfig"]["StoreNodes"] =  %* fleetConfig.getNodes(fleet, FleetNodes.Waku)
   nodeConfig["ClusterConfig"]["FilterNodes"] =  %* fleetConfig.getNodes(fleet, FleetNodes.Waku)
   nodeConfig["ClusterConfig"]["LightpushNodes"] =  %* fleetConfig.getNodes(fleet, FleetNodes.Waku)
+
+  #TODO: in the meantime we're using the go-waku test fleet for rendezvous.
+  #      once we have a prod fleet this code needs to be updated
+  nodeConfig["ClusterConfig"]["WakuRendezvousNodes"] =  %* fleetConfig.getNodes(Fleet.GoWakuTest, FleetNodes.LibP2P)
+
   return saveSetting(Setting.NodeConfig, nodeConfig)
 
 proc setV2LightMode*(enabled: bool): StatusGoError =

--- a/status/types/fleet.nim
+++ b/status/types/fleet.nim
@@ -9,13 +9,16 @@ type
     Test = "eth.test",
     WakuV2Prod = "wakuv2.prod"
     WakuV2Test = "wakuv2.test"
-
+    GoWakuTest = "go-waku.test"
+    
   FleetNodes* {.pure.} = enum
     Bootnodes = "boot",
     Mailservers = "mail",
     Rendezvous = "rendezvous",
     Whisper = "whisper",
     Waku = "waku"
+    LibP2P = "libp2p"
+    Websocket = "websocket"
 
   FleetMeta* = object
     hostname*: string


### PR DESCRIPTION
Requires
- https://github.com/status-im/status-go/pull/2422

This enables rendezvous for waku v2. It's using a hardcoded multiaddress for a go-waku node i have running on digitalocean. Once we have a fleet of go-waku nodes we need to remove this multiaddress