### PR TITLE
refactor: return object instead of string from stickers backend

### DIFF
--- a/status/chat/stickers.nim
+++ b/status/chat/stickers.nim
@@ -1,9 +1,4 @@
 import chronicles
-import ../stickers as status_stickers
+import ../stickers
 
-logScope:
-  topics = "sticker-decoding"
-
-# TODO: this is for testing purposes, the correct function should decode the hash
-proc decodeContentHash*(value: string): string =
-  status_stickers.decodeContentHash(value)
+export decodeContentHash

--- a/status/types/transaction.nim
+++ b/status/types/transaction.nim
@@ -5,6 +5,11 @@ import web3/ethtypes, options, stint
 include pending_transaction_type
 
 type
+  PendingTransaction* = ref object
+    hash*: string
+    success*: bool
+    txType*: PendingTransactionType
+
   Transaction* = ref object
     id*: string
     typeValue*: string
@@ -21,8 +26,8 @@ type
     value*: string
     fromAddress*: string
     to*: string
-  
-type 
+
+type
   TransactionData* = object
     source*: Address             # the address the transaction is send from.
     to*: Option[Address]         # (optional when creating new contract) the address the transaction is directed to.


### PR DESCRIPTION
Related to https://github.com/status-im/status-desktop/issues/3725.

Introduce `type PendingTransaction` in `status/types/transaction.nim`. Refactor `proc buyPack` in `status/stickers.nim` to return an instance of that type instead of `string`. Eliminate unnecessary threading of `var success` argument through successive calls in favor of tracking `success` in a field on `PendingTransaction`.

---

NOTES

Several files in this project have "sticker" in their names or make reference to "sticker". All those were reviewed as candidates for changes logically-related to the purpose of this PR:

`status/accounts.nim`
`status/chat.nim`
`status/chat/stickers.nim`
`status/eth/contracts.nim`
`status/eth/stickers.nim`
`status/status.nim`
`status/statusgo_backend/chat.nim`
`status/statusgo_backend/edn_helpers.nim`
`status/stickers.nim`
`status/types/message.nim`
`status/types/pending_transaction_type.nim`
`status/types/setting.nim`
`status/types/sticker.nim`
`status/utils.nim`
`status/wallet/collectibles.nim`

`sendStickerMessage` in `status/statusgo_backend/chat.nim` returns `string` but refactoring it seems out of scope for this set of changes.

A comment has been left in `status/stickers.nim` re: an additional refactor that can be made to simplify `trackPendingTransaction` as called by `buyPack`. The refactor will involve changes in other modules as well.

`type Message` in `status/types/message.nim` has a `sticker*: string` field that doesn't seem to be made use of by the Nim side of status-desktop, but it it is made use of by desktop's QML side (see: `status-desktop/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml`). In the future it may be preferable to use a different type, or a type alias for `string`.

`decodeContentHash` in `status/utils.nim` could return an instance of `type Cid` without converting it to a string, leaving it up to call sites in status-lib and status-desktop to convert to `string`.

`getStickers` in `status/wallet/collectibles.nim` returns `string`, used by `{.slot.}` procs in status-desktop (see Nim sources in `status-desktop/src/app`) that expose the JSON data (as `string`) to QML. Refactoring the return value seems out of scope for this PR, given ongoing refactors in status-desktop's front-end architecture.