### PR TITLE
fix: check if contract exists before getting address

### DIFF
--- a/status/ens.nim
+++ b/status/ens.nim
@@ -320,7 +320,10 @@ proc setPubKey*(username, pubKey, address, gas, gasPrice: string, isEIP1559Enabl
 
 proc statusRegistrarAddress*():string =
   let network = status_settings.getCurrentNetwork().toNetwork()
-  result = $contracts.findContract(network.chainId, "ens-usernames").address
+  let contract = contracts.findContract(network.chainId, "ens-usernames")
+  if contract != nil:
+     return $contract.address
+  result = ""
 
 type
   ENSType* {.pure.} = enum


### PR DESCRIPTION
Closes: #3963

This commit avoid crashing case. But looks like we have a problem in chainID (when we setup it not like `-1`)