### PR TITLE
fix: introduce missing contact related RPC APIs

### DIFF
--- a/status/contacts.nim
+++ b/status/contacts.nim
@@ -36,15 +36,11 @@ proc getContactByID*(self: ContactModel, id: string): Profile =
   return status_contacts.getContactByID(id)
   
 proc blockContact*(self: ContactModel, id: string) =
-  var contact = self.getContactByID(id)
-  contact.blocked = true
-  self.saveContact(contact)
+  status_contacts.blockContact(id)
   self.events.emit("contactBlocked", ContactIdArgs(id: id))
 
 proc unblockContact*(self: ContactModel, id: string) =
-  var contact = self.getContactByID(id)
-  contact.blocked = false
-  self.saveContact(contact)
+  status_contacts.unblockContact(id)
   self.events.emit("contactUnblocked", ContactIdArgs(id: id))
 
 proc getContacts*(self: ContactModel, useCache: bool = true): seq[Profile] =
@@ -83,7 +79,7 @@ proc setNickName*(self: ContactModel, id: string, localNickname: string, account
       localNickname
 
   contact.localNickname = nickname
-  self.saveContact(contact)
+  status_contacts.setContactLocalNickname(id, nickname);
   self.events.emit("contactAdded", Args())
   sendContactUpdate(contact.id, accountKeyUID)
 
@@ -119,11 +115,7 @@ proc addContact*(self: ContactModel, id: string, accountKeyUID: string) =
     self.events.emit("contactUpdate", ContactUpdateArgs(contacts: @[profile]))
 
 proc removeContact*(self: ContactModel, id: string) =
-  let contact = self.getContactByID(id)
-  contact.added = false
-  contact.hasAddedUs = false
-
-  self.saveContact(contact)
+  status_contacts.removeContact(id)
   self.events.emit("contactRemoved", Args())
 
 proc isAdded*(self: ContactModel, id: string): bool =

--- a/status/statusgo_backend/contacts.nim
+++ b/status/statusgo_backend/contacts.nim
@@ -47,25 +47,44 @@ proc getContactsIndex*(): (Table[string, Profile], bool)=
   discard getContacts()
   return (contactsIndex, false)
 
+proc blockContact*(id: string) =
+  discard callPrivateRPC("blockContact".prefix, %* [id])
+  dirty.store(true)
+
+proc unblockContact*(id: string) =
+  discard callPrivateRPC("unblockContact".prefix, %* [id])
+  dirty.store(true)
+
+proc removeContact*(id: string) =
+  discard callPrivateRPC("removeContact".prefix, %* [id])
+  dirty.store(true)
+
+proc rejectContactRequest*(id: string) =
+  let payload = %*[{
+    "id": id
+  }]
+  discard callPrivateRPC("rejectContactRequest".prefix, payload)
+  dirty.store(true)
+
+proc setContactLocalNickname*(id: string, name: string) =
+  let payload = %* [{
+    "id": id,
+    "nickname": name
+  }]
+  discard callPrivateRPC("setContactLocalNickname".prefix, payload)
+  dirty.store(true)
+
 proc saveContact*(id: string, ensVerified: bool, ensName: string, alias: string, 
   identicon: string, thumbnail: string, largeImage: string, added: bool, blocked: bool, 
   hasAddedUs: bool, localNickname: string) =
+  # TODO: Most of these method arguments aren't used anymore
+  # as status-go's RPC API became smarter. Should remove those.
   let payload = %* [{
       "id": id,
-      "name": ensName,
-      "ensVerified": ensVerified,
-      "alias": alias,
-      "identicon": identicon,
-      "images": {
-        "thumbnail": {"Payload": thumbnail.partition(",")[2]},
-        "large": {"Payload": largeImage.partition(",")[2]}
-        },
-      "added": added,
-      "blocked": blocked,
-      "hasAddedUs": hasAddedUs,
-      "localNickname": localNickname
+      "ensName": ensName
     }]
-  discard callPrivateRPC("saveContact".prefix, payload)
+
+  discard callPrivateRPC("addContact".prefix, payload)
   dirty.store(true)
 
 proc sendContactUpdate*(publicKey: string, accountKeyUID: string) =

--- a/status/statusgo_backend_new/contacts.nim
+++ b/status/statusgo_backend_new/contacts.nim
@@ -12,27 +12,40 @@ proc getContactById*(id: string): RpcResponse[JsonNode] {.raises: [Exception].} 
   let payload = %* [id]
   result = callPrivateRPC("getContactByID".prefix, payload)
 
+proc blockContact*(id: string) =
+  discard callPrivateRPC("blockContact".prefix, %* [id])
+
+proc unblockContact*(id: string) =
+  discard callPrivateRPC("unblockContact".prefix, %* [id])
+
+proc removeContact*(id: string) =
+  discard callPrivateRPC("removeContact".prefix, %* [id])
+
+proc rejectContactRequest*(id: string) =
+  let payload = %*[{
+    "id": id
+  }]
+  discard callPrivateRPC("rejectContactRequest".prefix, payload)
+
+proc setContactLocalNickname*(id: string, name: string) =
+  let payload = %* [{
+    "id": id,
+    "nickname": name
+  }]
+  discard callPrivateRPC("setContactLocalNickname".prefix, payload)
+
 proc saveContact*(id: string, ensVerified: bool, ensName: string, alias: string, 
   identicon: string, thumbnail: string, largeImage: string, added: bool, 
   blocked: bool, hasAddedUs: bool, localNickname: string) 
   {.raises: [Exception].} =
+  # TODO: Most of these method arguments aren't used anymore
+  # as status-go's RPC API became smarter. Should remove those.
   let payload = %* [{
-    "id": id,
-    "name": ensName,
-    "ensVerified": ensVerified,
-    "alias": alias,
-    "identicon": identicon,
-    "images": {
-      "thumbnail": {"Payload": thumbnail.partition(",")[2]},
-      "large": {"Payload": largeImage.partition(",")[2]}
-      },
-    "added": added,
-    "blocked": blocked,
-    "hasAddedUs": hasAddedUs,
-    "localNickname": localNickname
-  }]
+      "id": id,
+      "ensName": ensName
+    }]
 
-  discard callPrivateRPC("saveContact".prefix, payload)
+  discard callPrivateRPC("addContact".prefix, payload)
 
 proc sendContactUpdate*(publicKey, ensName, thumbnail: string)
   {.raises: [Exception].} =


### PR DESCRIPTION
There was a breaking change in status-go that has removed the
`saveContact` API which `status-lib` has used in various places to perform
changes on contact data.

There are now more dedicated APIs for contact related actions,
such as: `AddContact`, `RemoveContact`, `BlockContact` etc.

This commit introduces APIs for these RPC calls and adjusts other
APIs that relied on `saveContact` before.