### PR TITLE
refactor: privacy methods added

### DIFF
--- a/status/statusgo_backend_new/accounts.nim
+++ b/status/statusgo_backend_new/accounts.nim
@@ -136,9 +136,6 @@ proc storeAccounts*(id, hashedPassword: string): RpcResponse[JsonNode] {.raises:
     error "error doing rpc request", methodName = "storeAccounts", exception=e.msg
     raise newException(RpcException, e.msg)
 
-proc hashPassword*(password: string): string =
-  result = "0x" & $keccak_256.digest(password)
-
 proc saveAccount*(
   address: string,
   name: string,
@@ -238,15 +235,16 @@ proc multiAccountImportPrivateKey*(privateKey: string): RpcResponse[JsonNode] =
     error "error doing rpc request", methodName = "multiAccountImportPrivateKey", exception=e.msg
     raise newException(RpcException, e.msg)
 
-proc verifyAccountPassword*(address: string, password: string, keystoreDir: string): bool =
-  let hashedPassword = hashPassword(password)
-  let verifyResult = status_go.verifyAccountPassword(keystoreDir, address, hashedPassword)
-  let error = parseJson(verifyResult)["error"].getStr
+proc verifyAccountPassword*(address: string, password: string, keystoreDir: string): 
+  RpcResponse[JsonNode] {.raises: [Exception].} =
+  try:
+    let hashedPassword = hashPassword(password)
+    let response = status_go.verifyAccountPassword(keystoreDir, address, hashedPassword)
+    result.result = Json.decode(response, JsonNode)
 
-  if error == "":
-    return true
-
-  return false
+  except RpcException as e:
+    error "error doing rpc request", methodName = "verifyAccountPassword", exception=e.msg
+    raise newException(RpcException, e.msg)
   
 proc storeIdentityImage*(keyUID: string, imagePath: string, aX, aY, bX, bY: int): 
   RpcResponse[JsonNode] {.raises: [Exception].} =

--- a/status/statusgo_backend_new/eth.nim
+++ b/status/statusgo_backend_new/eth.nim
@@ -31,3 +31,6 @@ proc doEthCall*(payload = %* []): RpcResponse[JsonNode] {.raises: [Exception].} 
 
 proc estimateGas*(payload = %* []): RpcResponse[JsonNode] {.raises: [Exception].} =
   core.callPrivateRPC("eth_estimateGas", payload)
+
+proc getEthAccounts*(): RpcResponse[JsonNode] {.raises: [Exception].} =
+  return core.callPrivateRPC("eth_accounts")

--- a/status/statusgo_backend_new/privacy.nim
+++ b/status/statusgo_backend_new/privacy.nim
@@ -1,0 +1,25 @@
+import json, json_serialization, chronicles
+import core, utils
+import response_type
+
+import status_go
+
+export response_type
+
+logScope:
+  topics = "rpc-privacy"
+
+proc changeDatabasePassword*(keyUID: string, password: string, newPassword: string): RpcResponse[JsonNode] 
+  {.raises: [Exception].} =
+  try:
+    let hashedPassword = hashPassword(password)
+    let hashedNewPassword = hashPassword(newPassword)
+    let response = status_go.changeDatabasePassword(keyUID, hashedPassword, hashedNewPassword)
+    result.result = Json.decode(response, JsonNode)
+  except RpcException as e:
+    error "error", methodName = "changeDatabasePassword", exception=e.msg
+    raise newException(RpcException, e.msg)
+
+proc getLinkPreviewWhitelist*(): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* []
+  result = callPrivateRPC("getLinkPreviewWhitelist".prefix, payload)

--- a/status/statusgo_backend_new/utils.nim
+++ b/status/statusgo_backend_new/utils.nim
@@ -1,3 +1,5 @@
+import nimcrypto
+
 proc isWakuEnabled(): bool =
   true # TODO:
 
@@ -5,3 +7,6 @@ proc prefix*(methodName: string, isExt:bool = true): string =
   result = if isWakuEnabled(): "waku" else: "shh" 
   result = result & (if isExt: "ext_" else: "_")
   result = result & methodName
+
+proc hashPassword*(password: string): string =
+  result = "0x" & $keccak_256.digest(password)


### PR DESCRIPTION
- methods `changeDatabasePassword` and `getLinkPreviewWhitelist` added
to `privacy.nim`
- `hashPassword` moved to `utils.nim` since it's used from multiple paces
- `getEthAccounts` added to `eth.nim`
- `verifyAccountPassword` method updated so it returns `RpcResponse` now